### PR TITLE
added spaces in detectionprofiles view for improved readability

### DIFF
--- a/src/resources/js/components/DetectionProfiles.vue
+++ b/src/resources/js/components/DetectionProfiles.vue
@@ -49,7 +49,7 @@
 
 
             <b-table-column field="object_classes" label="Object Classes" v-slot="props">
-                {{ props.row.is_negative ? 'NEG: ' : '' }}{{ props.row.object_classes.join('|') }}
+                {{ props.row.is_negative ? 'NEG: ' : '' }}{{ props.row.object_classes.join(' | ') }}
             </b-table-column>
 
             <b-table-column field="min_confidence" label="Min Confidence" v-slot="props">


### PR DESCRIPTION
Added spaces around the `|` separator to improve the table layout and readability. The fixes a ui issue when using a lot of object classes by enabling line breaks in this field.